### PR TITLE
Stop the version fallback drifting on every release

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -272,7 +272,7 @@ turning them into Odoo traffic is a self-inflicted load problem. A broken Odoo
 surfaces as failing tool calls, which is where it belongs.
 
 ```bash
-curl -s http://127.0.0.1:3000/health   # {"status":"ok","version":"1.2.0"}
+curl -s http://127.0.0.1:3000/health   # {"status":"ok","version":"2.0.0"}
 curl -s http://127.0.0.1:3000/ready    # {"status":"ready"}
 ```
 

--- a/scripts/mutations.mjs
+++ b/scripts/mutations.mjs
@@ -107,8 +107,15 @@ export const mutations = [
     id: "server/wrong-version",
     file: "src/server.ts",
     description: "advertise a version that is not the package version",
-    find: "version: SERVER_VERSION",
-    replace: 'version: "0.0.0-wrong"',
+    find: "version: deps?.version ?? SERVER_VERSION,",
+    replace: 'version: "0.0.0-wrong",',
+  },
+  {
+    id: "server/ignore-explicit-version",
+    file: "src/server.ts",
+    description: "ignore a caller-supplied version override",
+    find: "version: deps?.version ?? SERVER_VERSION,",
+    replace: "version: SERVER_VERSION,",
   },
   {
     id: "server/drop-annotations",

--- a/src/http-server.test.ts
+++ b/src/http-server.test.ts
@@ -133,6 +133,24 @@ describe("http-server", () => {
       await client.close();
       await handler.close();
     });
+
+    it("advertises an explicitly supplied version over the protocol", async () => {
+      // Filesystem-less deployments (Cloudflare Workers) cannot read
+      // package.json, so they need a way to report something better than the
+      // sentinel — and it has to actually reach the client.
+      const odooClient = new MockClientBuilder().build();
+      const handler = createMcpHttpHandler(() =>
+        createServer({ client: odooClient, version: "9.9.9-custom" }),
+      );
+      const client = await connectClient(handler, {
+        versionNegotiation: { mode: "legacy" },
+      });
+
+      expect(client.getServerVersion()?.version).toBe("9.9.9-custom");
+
+      await client.close();
+      await handler.close();
+    });
   });
 
   describe("tool metadata", () => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -279,15 +279,18 @@ describe("server", () => {
       expect(SERVER_VERSION).toBe(pkg.default.version);
     });
 
-    it("keeps the no-filesystem fallback in step with package.json", async () => {
-      // Runtimes without a module-relative filesystem (Cloudflare Workers) use
-      // FALLBACK_SERVER_VERSION. Nothing else would catch it going stale, and
-      // it is reported to clients as serverInfo.
+    it("uses a sentinel fallback that cannot go stale", async () => {
+      // An earlier version of this pinned FALLBACK_SERVER_VERSION to the
+      // current version and asserted the two matched. `changeset version` bumps
+      // package.json automatically, so the release PR broke this test — and
+      // left unfixed it would have shipped a stale version to every
+      // filesystem-less client. The fallback must stay a sentinel.
       const pkg = (await import("../package.json", {
         with: { type: "json" },
       })) as { default: { version: string } };
 
-      expect(FALLBACK_SERVER_VERSION).toBe(pkg.default.version);
+      expect(FALLBACK_SERVER_VERSION).not.toBe(pkg.default.version);
+      expect(FALLBACK_SERVER_VERSION).toMatch(/unknown/);
     });
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,12 +24,17 @@ import {
 import type { IOdooClient } from "./types/index.js";
 
 /**
- * Fallback for runtimes with no module-relative filesystem, such as Cloudflare
- * Workers, where `import.meta.url` is not a file URL and `createRequire`
- * throws. Kept in step with package.json by a test — a wrong version here is
- * reported to every client as `serverInfo`.
+ * Reported when the real version cannot be read: runtimes with no
+ * module-relative filesystem, such as Cloudflare Workers, where
+ * `import.meta.url` is not a file URL and `createRequire` throws.
+ *
+ * Deliberately a sentinel rather than a copy of the current version. A literal
+ * here would have to be updated by hand every release, and `changeset version`
+ * bumps package.json automatically — so it would go stale silently and report a
+ * wrong version to every client. Pass `version` to `createServer` if a
+ * filesystem-less deployment needs to advertise a real one.
  */
-export const FALLBACK_SERVER_VERSION = "1.2.0";
+export const FALLBACK_SERVER_VERSION = "0.0.0+unknown";
 
 /**
  * Version advertised to MCP clients. Read from package.json so it cannot drift
@@ -113,6 +118,14 @@ export interface ServerDependencies {
    * Defaults to the standard Odoo tool registry if not provided.
    */
   toolRegistry?: ToolRegistry;
+  /**
+   * Version advertised to clients as `serverInfo`.
+   *
+   * Defaults to the version read from package.json. Supply it where that read
+   * is impossible — a Cloudflare Worker has no module-relative filesystem, so
+   * without this it reports {@link FALLBACK_SERVER_VERSION}.
+   */
+  version?: string;
 }
 
 /**
@@ -141,7 +154,11 @@ export function formatToolResult(result: ToolResult): string {
  */
 export function createServer(deps?: ServerDependencies): McpServer {
   const server = new McpServer(
-    { name: SERVER_NAME, title: "Odoo MCP Server", version: SERVER_VERSION },
+    {
+      name: SERVER_NAME,
+      title: "Odoo MCP Server",
+      version: deps?.version ?? SERVER_VERSION,
+    },
     { capabilities: { tools: {}, resources: {} } },
   );
 


### PR DESCRIPTION
Fixes the red build on the release PR (#9).

## What broke

One test failed on `chore: release package`:

```
keeps the no-filesystem fallback in step with package.json
  Expected: "2.0.0"   Received: "1.2.0"
```

`main` itself is green — all eight workflows passed on the merge commit. The
failure only appears on the release PR, because that is the first place
`changeset version` bumps `package.json`.

The "Mutation testing FAILED" alongside it is a consequence, not a second
problem: the runner refuses to score mutants against a red baseline, since every
mutant would appear killed.

## Cause

`FALLBACK_SERVER_VERSION` was introduced as a literal copy of the current
version, with a test asserting the two matched. But `changeset version` bumps
`package.json` automatically, so the constant goes stale on every single
release — and the test fails the moment it does.

That is the same drift removed from the tool schemas earlier in #8, reintroduced
here: two declarations of one fact, one of them machine-updated.

## Fix

The fallback is now a sentinel, `"0.0.0+unknown"`, which no release can
invalidate. The test asserts it *stays* a sentinel rather than pinning it to a
number, so the drift cannot be reintroduced by someone "helpfully" setting it to
the current version.

Reporting an honest unknown is better than reporting a stale version — the
fallback only applies where `package.json` cannot be read (Cloudflare Workers),
and a confidently wrong `serverInfo` is worse than an obviously absent one.

Deployments that want a real version there can now supply one:

```ts
createServer({ client, version: "2.0.0" })
```

Verified over the protocol with a real MCP client rather than by construction,
since `serverInfo` is the only thing a client actually sees.

## Verification

- Simulated the release by setting `package.json` to `2.0.0`: **453 tests pass
  at both `1.2.0` and `2.0.0`**, which is the case that was failing.
- Mutation catalogue updated for the moved call site, plus a new mutant covering
  the version override. 28/28 caught.
- Lint, typecheck, build green.

Once this is on `main`, changesets will refresh #9 and it should go green.
